### PR TITLE
Fixing slack notifier creation.

### DIFF
--- a/consul-alerts.go
+++ b/consul-alerts.go
@@ -241,7 +241,7 @@ func builtinNotifiers() map[string]notifier.Notifier {
 	emailNotifier := consulClient.EmailNotifier()
 	logNotifier := consulClient.LogNotifier()
 	influxdbNotifier := consulClient.InfluxdbNotifier()
-	slackNotifier := consulClient.SlackNotifier
+	slackNotifier := consulClient.SlackNotifier()
 	mattermostNotifier := consulClient.MattermostNotifier()
 	pagerdutyNotifier := consulClient.PagerDutyNotifier()
 	hipchatNotifier := consulClient.HipChatNotifier()


### PR DESCRIPTION
This PR introduces a fix for the typo that leads to a compile error in the `consul-alerts.go` module.